### PR TITLE
Update for compatibility with Objection 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ try {
 These options can be provided when instantiating the plugin:
 
 ```js
-const unique = require('objection-unique')(
+const unique = require('objection-unique')({
   fields: ['email', 'username'],
   identifiers: ['id']
-);
+});
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -63,7 +63,10 @@ module.exports = options => {
             const errors = this.parseErrors(rows);
 
             if (!isEmpty(errors)) {
-              throw Model.createValidationError(errors);
+              throw Model.createValidationError({
+                data: errors,
+                type: 'ModelValidation'
+              });
             }
           });
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1779,6 +1779,12 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -2701,14 +2707,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2717,6 +2715,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4433,27 +4439,32 @@
       }
     },
     "objection": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/objection/-/objection-0.8.5.tgz",
-      "integrity": "sha1-sXp46uqBU6somyTHWhKidqI+/5U=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-1.0.0.tgz",
+      "integrity": "sha512-Wn2vmI5TyrTCRDBKYtr405x57OkiUsgAmJWGvjecrjzls5RZijzBvKr8yrTphzAg/2jctoSQjiYd0lA54P6Utw==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
-        "bluebird": "3.5.0",
+        "ajv": "6.2.0",
+        "bluebird": "3.5.1",
         "lodash": "4.17.4"
       },
       "dependencies": {
         "ajv": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",
+          "integrity": "sha1-r6wpW7qgFSRJ5SJ0LkVHwa6TKNI=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
             "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
+        },
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
         }
       }
     },
@@ -6447,15 +6458,6 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -6474,6 +6476,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jest": "^20.0.3",
     "knex": "^0.13.0",
     "lint-staged": "^3.4.1",
-    "objection": "^0.8.5",
+    "objection": "^1.0.0",
     "pre-commit": "^1.2.2",
     "sqlite3": "^3.1.8"
   },


### PR DESCRIPTION
Objection 1.0.0 changes the signature for `createValidationError`.
See: http://vincit.github.io/objection.js/#breaking-changes

Changes here allow this plugin to work with Objection 1.0.0, but probably break compatibility with older versions.

Bonus typo fix in the readme.