### PR TITLE
Add objection to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
     "pre-commit": "^1.2.2",
     "sqlite3": "^3.1.8"
   },
+  "peerDependencies": {
+    "objection": ">=1.0.0"
+  },
   "engines": {
     "node": ">=6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,14 +45,13 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.1:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
+ajv@^6.1.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.2.0.tgz#afac295bbaa0152449e522742e4547c1ae9328d2"
   dependencies:
-    co "^4.6.0"
     fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
-    json-stable-stringify "^1.0.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -690,9 +689,13 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.4.6, bluebird@^3.5.0:
+bluebird@^3.4.6:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
+
+bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1310,6 +1313,10 @@ extsprintf@1.0.2:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -2635,12 +2642,12 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-objection@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/objection/-/objection-0.8.5.tgz#b17a78eaea8153ab289b24c75a12a276a23eff95"
+objection@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/objection/-/objection-1.0.0.tgz#d41bc42e31705e991ee64a3345b25035f6e975ee"
   dependencies:
-    ajv "^5.1.1"
-    bluebird "^3.5.0"
+    ajv "^6.1.1"
+    bluebird "^3.5.1"
     lodash "^4.17.4"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:


### PR DESCRIPTION
This PR adds objection.js to the peer dependencies ensuring that the minimum installed version is `1.0.0`.
