### PR TITLE
Fix bug with null values in compound keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,12 +83,16 @@ module.exports = options => {
             return queries;
           }
 
-          const query = (
-            fields.reduce(
-              (subset, fieldName) => subset.where(fieldName, this[fieldName] || queryOptions.old[fieldName]),
-              collection.select(),
-            )
-          ).limit(1);
+          const query = fields
+            .reduce((subset, fieldName) => {
+              const oldFieldValue = queryOptions.old && queryOptions.old[fieldName];
+
+              return subset.where(
+                fieldName,
+                this[fieldName] || oldFieldValue || null
+              );
+            }, collection.select())
+            .limit(1);
 
           if (update) {
             options.identifiers.forEach(identifier =>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,6 +77,17 @@ describe('FoobarController', () => {
 
       expect(result).toEqual({ bar: 'bar', biz: 'biz', foo: 'foo', id });
     });
+
+    it('should handle null values in compound keys', async () => {
+      const TestModel = modelFactory({
+        fields: [['bar', 'foo']]
+      });
+
+      const { id } = await TestModel.query().insert({ bar: 'bar' });
+      const result = await TestModel.query().findById(id);
+
+      expect(result).toEqual({ bar: 'bar', biz: null, foo: null, id: 1 });
+    });
   });
 
   describe('$beforeUpdate', () => {


### PR DESCRIPTION
When having a null value in compound keys it would raise an exception
because it attempts to find the column in queryOptions.old which does
not exist when inserting an item. Instead, return null so check can
complete.