### PR TITLE
Fix leaking transaction, favor transaction from context over creating new one

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = options => {
 
       getQuery(update, queryOptions, context) {
         return options.fields.reduce((queries, field, index) => {
-          const knex = Model.knex() || context.transaction;
+          const knex = context.transaction || Model.knex();
           const collection = knex(this.constructor.tableName);
           const fields = castArray(field);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,6 +88,21 @@ describe('FoobarController', () => {
 
       expect(result).toEqual({ bar: 'bar', biz: null, foo: null, id: 1 });
     });
+
+    it('should favor transaction from context', async () => {
+      const TestModel = modelFactory({
+        fields: [['bar', 'foo']]
+      });
+
+      const result = await TestModel.knex().transaction(async trx => {
+        const { id } = await TestModel.query(trx).insert({ bar: 'bar', biz: 'biz', foo: 'foo' });
+        const result = await TestModel.query(trx).findById(id);
+
+        return result;
+      });
+
+      expect(result).toEqual({ bar: 'bar', biz: 'biz', foo: 'foo', id: 1 });
+    });
   });
 
   describe('$beforeUpdate', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,7 +17,7 @@ describe('FoobarController', () => {
 
   it('should throw an error if there is no fields or identifiers options.', () => {
     try {
-      const TestModel = modelFactory();
+      modelFactory();
 
       fail();
     } catch (e) {


### PR DESCRIPTION
When doing operations within a transaction a new one was started rather
than using the current one, causing a "leaking" connection. This became
more evident when trying to run tests with only 1 connection pool.